### PR TITLE
Fixed 'mid' parsing

### DIFF
--- a/sdp_transform/grammar.py
+++ b/sdp_transform/grammar.py
@@ -411,16 +411,16 @@ grammar = {
             'format': 'floorid:%s mstrm:%s'
         },
         {
-            # any a= that we don't understand is kept verbatim on media.invalid
-            'push': 'invalid',
-            'names': ['value']
-        },
-        {
             # a=mid:1
             'name': 'mid',
             'reg': "^mid:([^\s]*)",
             'format': 'mid:%s'
-        }
+        },
+        {
+            # any a= that we don't understand is kept verbatim on media.invalid
+            'push': 'invalid',
+            'names': ['value']
+        },
     ]
 }
 


### PR DESCRIPTION
Currently mid parsing does not work and will always get pushed as 'invalid'.
Changed the grammar ordering to fix this.